### PR TITLE
fix(specificity): Fix incorrect `:where` usage.

### DIFF
--- a/lib/component/BaseButton/BaseButton.tsx
+++ b/lib/component/BaseButton/BaseButton.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import classNames from 'classnames/dedupe';
 import { pcake } from '../../utils/strings';
 
 import classes from './base-button.module.scss';

--- a/lib/component/BaseButton/base-button.module.scss
+++ b/lib/component/BaseButton/base-button.module.scss
@@ -1,4 +1,4 @@
-.root {
+:where(:global(.pcake).root) {
   border-radius: var(--curvature);
 
   background-color: var(--primary);

--- a/lib/component/IconButton/IconButton.tsx
+++ b/lib/component/IconButton/IconButton.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import classNames from 'classnames/dedupe';
 import { ReactNode } from 'react';
 import { pcake } from '../../utils/strings';
 import { BaseButton, BaseButtonProps } from '../BaseButton';

--- a/lib/component/IconButton/icon-button.module.scss
+++ b/lib/component/IconButton/icon-button.module.scss
@@ -1,4 +1,4 @@
-.root {
+:where(:global(.pcake).root) {
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/lib/component/Surface/surface.module.scss
+++ b/lib/component/Surface/surface.module.scss
@@ -1,4 +1,4 @@
-:global(.pcake):where(.root) {
+:where(:global(.pcake).root) {
   border-radius: var(--curvature);
   background-color: var(--primary);
 }

--- a/lib/component/TextButton/text-button.module.scss
+++ b/lib/component/TextButton/text-button.module.scss
@@ -1,4 +1,4 @@
-.root {
+:where(:global(.pcake).root) {
   display: inline-flex;
   align-items: center;
   padding: 0.75rem 1.5rem;
@@ -15,6 +15,6 @@
   }
 }
 
-.children {
+:where(.children) {
   flex: 1 0 auto;
 }

--- a/lib/reset.css
+++ b/lib/reset.css
@@ -1,7 +1,7 @@
 /*** Based on The new CSS Reset - version 1.2.0 ***/
 
 /* Remove all the styles of the "User-Agent-Stylesheet", except for the 'display' property */
-.pcake:where(:not(iframe, canvas, img, svg, video):not(svg *)) {
+:where(.pcake:not(iframe, canvas, img, svg, video):not(svg *)) {
   all: unset;
   display: revert;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,21 @@
-import { Surface } from '../lib';
+import { BaseButton, IconButton, Surface, TextButton } from '../lib';
 import { Heli } from './Heli';
 
 function App() {
   return (
-    <>
-      {/* <BaseButton style={{ color: 'white' }}>BUTTON</BaseButton>
+    <div className="aa">
+      <BaseButton style={{ color: 'white' }}>BUTTON</BaseButton>
       <TextButton style={{ color: 'white' }}>BUTTON</TextButton>
       <TextButton preText={<Heli />} style={{ color: 'white' }}>BUTTON</TextButton>
       <TextButton style={{ color: 'white' }} postText={<Heli />}>BUTTON</TextButton>
       <TextButton preText={<Heli />} style={{ color: 'white' }} postText={<Heli />}>BUTTON</TextButton>
       <TextButton preText={<Heli />} style={{ color: 'white', fontSize: '30px' }} postText={<Heli />}>BUTTON</TextButton>
-      <IconButton style={{ color: 'white' }}><Heli /></IconButton> */}
+      <IconButton style={{ color: 'white' }}><Heli /></IconButton>
       <Surface component='div' style={{ width: 200, height: 200 }}>
         bbb
         <Heli />
       </Surface>
-    </>
+    </div>
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -10,3 +10,7 @@ html, body, #root {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 
 }
+
+.aa > * {
+  background-color: red;
+}


### PR DESCRIPTION
The way CSS rules were expressed, .`pcake:where(...)`, is problematic, as its resolved specificity is `(0, 1, 0)`, not `(0, 0, 0)`.

It was changed to `:where(:global(.pcake) ...)`. The `:global` selector tells the modules parser to resolve `.pcake` as-is, and since the entire rule is inside `:where`, specificity remains at 0. 

ATM it seems to work perfectly, and any styles from outside are applied. We need to make sure everything stays that way, and perhaps more importantly - that our own CSS rules with specificity 0 don't override each other incorrectly.